### PR TITLE
Make configuration section in readmes more explicit

### DIFF
--- a/camel-quarkus/README.md
+++ b/camel-quarkus/README.md
@@ -11,6 +11,7 @@ This project uses Quarkus [Container Images](https://quarkus.io/guides/container
 The most important part in terms of the _hawtio-enabled_ configuration is defined in the `<properties>` section. To make it _hawtio-enabled_, the Jolokia agent must be attached to the application with HTTPS and SSL client authentication configured. The client principal should match those the Hawtio Online instance provides (the default is `hawtio-online.hawtio.svc`).
 
 ```xml
+<properties>
     <jolokia.protocol>https</jolokia.protocol>
     <jolokia.host>*</jolokia.host>
     <jolokia.port>8778</jolokia.port>
@@ -19,6 +20,7 @@ The most important part in terms of the _hawtio-enabled_ configuration is define
     <jolokia.clientPrincipal.1>cn=hawtio-online.hawtio.svc</jolokia.clientPrincipal.1>
     <jolokia.extendedClientCheck>true</jolokia.extendedClientCheck>
     <jolokia.discoveryEnabled>false</jolokia.discoveryEnabled>
+</properties>
 ```
 
 ## How to run locally

--- a/camel-springboot/README.md
+++ b/camel-springboot/README.md
@@ -11,14 +11,26 @@ This project uses JKube [kubernetes-maven-plugin](https://eclipse.dev/jkube/docs
 All you need to make the application _hawtio-enabled_ is to define additional environment variables to the deployment resource to fine-tune the Jolokia agent options. By default, JKube plugin sets up a Jolokia agent with HTTPS and SSL client authentication enabled. The only necessary configurations are the client principal that matches the Hawtio Online instance (the default is `hawtio-online.hawtio.svc`) and the CA cert to specify `service-ca.crt` instead of the default `ca.crt`.
 
 ```xml
-<configuration>
-  <resources>
-    <env>
-      <AB_JOLOKIA_AUTH_OPENSHIFT>cn=hawtio-online.hawtio.svc</AB_JOLOKIA_AUTH_OPENSHIFT>
-      <AB_JOLOKIA_OPTS>caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt</AB_JOLOKIA_OPTS>
-    </env>
-  </resources>
-</configuration>
+<plugin>
+  <groupId>org.eclipse.jkube</groupId>
+  <artifactId>kubernetes-maven-plugin</artifactId>
+  <version>${kubernetes-maven-plugin-version}</version>
+  <configuration>
+    <resources>
+      <env>
+        <!--
+          By default, JKube plugin sets up a Jolokia agent with HTTPS and
+          SSL client authentication enabled. The only necessary configurations
+          are the client principal that matches the Hawtio Online instance
+          (the default is `hawtio-online.hawtio.svc`) and the CA cert to
+          specify `service-ca.crt` instead of the default `ca.crt`.
+        -->
+        <AB_JOLOKIA_AUTH_OPENSHIFT>cn=hawtio-online.hawtio.svc</AB_JOLOKIA_AUTH_OPENSHIFT>
+        <AB_JOLOKIA_OPTS>caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt</AB_JOLOKIA_OPTS>
+      </env>
+    </resources>
+  </configuration>
+</plugin>
 ```
 
 ## How to run locally


### PR DESCRIPTION
I think it is more readable to have the context for where the configuration should be in the Readme so users know where to look in the poms.