### PR TITLE
E2E test support changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           mvn --batch-mode --no-transfer-progress install -Djkube.build.strategy=docker
       - name: Push image to Quay.io
+        if: github.event_name == 'push'
         env:
           USERNAME: ${{ secrets.QUAY_USERNAME }}
           PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/camel-quarkus/pom.xml
+++ b/camel-quarkus/pom.xml
@@ -123,6 +123,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-timer</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jolokia</groupId>
       <artifactId>jolokia-agent-jvm</artifactId>
       <version>${jolokia-version}</version>

--- a/camel-quarkus/src/main/resources/application.properties
+++ b/camel-quarkus/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.log.category."io.undertow".level = WARN
 quarkus.log.category."org.apache.camel".level = INFO
 
 # Camel
-camel.context.name = SampleCamelQuarkus
+camel.context.name = SampleCamel
 
 # Enable the Camel plugin Trace tab
 #camel.main.tracing = true

--- a/camel-springboot/pom.xml
+++ b/camel-springboot/pom.xml
@@ -55,6 +55,10 @@
       <groupId>org.apache.camel.springboot</groupId>
       <artifactId>camel-quartz-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-timer-starter</artifactId>
+    </dependency>
     <!--
       This dependency is mandatory for enabling Camel management
       via JMX / Hawtio.

--- a/camel-springboot/src/main/resources/application.properties
+++ b/camel-springboot/src/main/resources/application.properties
@@ -10,7 +10,7 @@ logging.level.org.springframework = WARN
 logging.level.io.undertow = WARN
 
 # Camel
-camel.springboot.name = SampleCamelSpringBoot
+camel.springboot.name = SampleCamel
 
 # Enable the Camel plugin Trace tab
 #camel.springboot.tracing = true


### PR DESCRIPTION
With these changes I'm able to run E2E testsuite from hawtio on these apps connected via hawtio-online, so we will have always have test coverage for these examples.