### PR TITLE
Add multi-arch builds for hawtio-online-example images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - multiarch-build
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - multiarch-build
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,6 +16,8 @@ jobs:
       matrix:
         java: ['17', '21']
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Java
@@ -24,13 +26,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
-      - name: Build
-        run: |
-          mvn --batch-mode --no-transfer-progress install -Djkube.build.strategy=docker
-      - name: List images
-        run: |
-          docker images
-      - name: Push image to Quay.io
+      - name: Build and push image to Quay.io
         if: github.event_name == 'push'
         env:
           USERNAME: ${{ secrets.QUAY_USERNAME }}
@@ -38,14 +34,23 @@ jobs:
         run: |
           docker login --help
           docker login -u $USERNAME -p $PASSWORD quay.io
-          docker tag quay.io/hawtio/hawtio-online-example-camel-quarkus-kube:latest quay.io/hawtio/hawtio-online-example-camel-quarkus:${{matrix.java}}
-          docker tag quay.io/hawtio/hawtio-online-example-camel-springboot:latest quay.io/hawtio/hawtio-online-example-camel-springboot:${{matrix.java}}
 
-          docker push quay.io/hawtio/hawtio-online-example-camel-quarkus:${{matrix.java}}
-          docker push quay.io/hawtio/hawtio-online-example-camel-springboot:${{matrix.java}}
+          mvn --batch-mode --no-transfer-progress -pl '!camel-quarkus-openshift' install \
+            -Dquarkus.jib.base-jvm-image=registry.access.redhat.com/ubi9/openjdk-${{ matrix.java }}-runtime:latest \
+            -Dquarkus.jib.platforms=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+            -Dquarkus.container-image.name=hawtio-online-example-camel-quarkus \
+            -Dquarkus.container-image.tag=${{ matrix.java }} \
+            -Dquarkus.container-image.push=true \
+            -Djkube.generator.from=registry.access.redhat.com/ubi9/openjdk-${{ matrix.java }}:latest \
+            -Djkube.build.strategy=docker
 
-          if [[ "${{matrix.java}}" == "21" ]]; then
-            docker tag quay.io/hawtio/hawtio-online-example-camel-quarkus-kube:latest quay.io/hawtio/hawtio-online-example-camel-quarkus:latest
-            docker push quay.io/hawtio/hawtio-online-example-camel-quarkus:latest
-            docker push quay.io/hawtio/hawtio-online-example-camel-springboot:latest
+          docker buildx build -t quay.io/hawtio/hawtio-online-example-camel-springboot:${{ matrix.java }} \
+            --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+            --provenance=false \
+            --push \
+            camel-springboot/target/docker/quay.io/hawtio/hawtio-online-example-camel-springboot/latest/build/
+
+          if [[ "${{ matrix.java }}" == "21" ]]; then
+            docker buildx imagetools create -t quay.io/hawtio/hawtio-online-example-camel-quarkus:latest quay.io/hawtio/hawtio-online-example-camel-quarkus:${{ matrix.java }}
+            docker buildx imagetools create -t quay.io/hawtio/hawtio-online-example-camel-springboot:latest quay.io/hawtio/hawtio-online-example-camel-springboot:${{ matrix.java }}
           fi

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         java: ['17', '21']
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Java
@@ -35,20 +33,20 @@ jobs:
           docker login --help
           docker login -u $USERNAME -p $PASSWORD quay.io
 
-          mvn --batch-mode --no-transfer-progress -pl '!camel-quarkus-openshift' install \
-            -Dquarkus.jib.base-jvm-image=registry.access.redhat.com/ubi9/openjdk-${{ matrix.java }}-runtime:latest \
-            -Dquarkus.jib.platforms=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
-            -Dquarkus.container-image.name=hawtio-online-example-camel-quarkus \
-            -Dquarkus.container-image.tag=${{ matrix.java }} \
-            -Dquarkus.container-image.push=true \
-            -Djkube.generator.from=registry.access.redhat.com/ubi9/openjdk-${{ matrix.java }}:latest \
-            -Djkube.build.strategy=docker
+          mvn --batch-mode --no-transfer-progress -pl 'camel-quarkus-kubernetes' install \
+          -Dquarkus.jib.base-jvm-image=registry.access.redhat.com/ubi9/openjdk-${{ matrix.java }}-runtime:latest \
+          -Dquarkus.jib.platforms=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+          -Dquarkus.container-image.name=hawtio-online-example-camel-quarkus \
+          -Dquarkus.container-image.tag=${{ matrix.java }} \
+          -Dquarkus.container-image.push=true
 
-          docker buildx build -t quay.io/hawtio/hawtio-online-example-camel-springboot:${{ matrix.java }} \
-            --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
-            --provenance=false \
-            --push \
-            camel-springboot/target/docker/quay.io/hawtio/hawtio-online-example-camel-springboot/latest/build/
+          mvn --batch-mode --no-transfer-progress -pl 'camel-springboot' package k8s:build k8s:push \
+          -Djkube.container-image.from=registry.access.redhat.com/ubi9/openjdk-${{ matrix.java }}:latest \
+          -Djkube.container-image.platforms.1=linux/amd64 \
+          -Djkube.container-image.platforms.2=linux/arm64 \
+          -Djkube.container-image.platforms.3=linux/ppc64le \
+          -Djkube.container-image.platforms.4=linux/s390x \
+          -Djkube.container-image.name=quay.io/hawtio/hawtio-online-example-camel-springboot:${{ matrix.java }}
 
           if [[ "${{ matrix.java }}" == "21" ]]; then
             docker buildx imagetools create -t quay.io/hawtio/hawtio-online-example-camel-quarkus:latest quay.io/hawtio/hawtio-online-example-camel-quarkus:${{ matrix.java }}

--- a/camel-springboot/README.md
+++ b/camel-springboot/README.md
@@ -6,31 +6,21 @@ This sample application shows how to make it hawtio-enabled with Camel Spring Bo
 
 - [pom.xml](pom.xml)
 
-This project uses JKube [kubernetes-maven-plugin](https://eclipse.dev/jkube/docs/kubernetes-maven-plugin/) to build a container image and deploy it to a Kubernetes/OpenShift cluster. JKube supports Jolokia out of the box and the default base image already includes Jolokia agent.
+This project uses JKube [kubernetes-maven-plugin](https://eclipse.dev/jkube/docs/kubernetes-maven-plugin/) to build a container image and deploy it to a Kubernetes/OpenShift cluster.
 
-All you need to make the application _hawtio-enabled_ is to define additional environment variables to the deployment resource to fine-tune the Jolokia agent options. By default, JKube plugin sets up a Jolokia agent with HTTPS and SSL client authentication enabled. The only necessary configurations are the client principal that matches the Hawtio Online instance (the default is `hawtio-online.hawtio.svc`) and the CA cert to specify `service-ca.crt` instead of the default `ca.crt`.
+The most important part in terms of the _hawtio-enabled_ configuration is defined in the `<properties>` section. To make it _hawtio-enabled_, the Jolokia agent must be attached to the application with HTTPS and SSL client authentication configured. The client principal should match those the Hawtio Online instance provides (the default is `hawtio-online.hawtio.svc`).
 
 ```xml
-<plugin>
-  <groupId>org.eclipse.jkube</groupId>
-  <artifactId>kubernetes-maven-plugin</artifactId>
-  <version>${kubernetes-maven-plugin-version}</version>
-  <configuration>
-    <resources>
-      <env>
-        <!--
-          By default, JKube plugin sets up a Jolokia agent with HTTPS and
-          SSL client authentication enabled. The only necessary configurations
-          are the client principal that matches the Hawtio Online instance
-          (the default is `hawtio-online.hawtio.svc`) and the CA cert to
-          specify `service-ca.crt` instead of the default `ca.crt`.
-        -->
-        <AB_JOLOKIA_AUTH_OPENSHIFT>cn=hawtio-online.hawtio.svc</AB_JOLOKIA_AUTH_OPENSHIFT>
-        <AB_JOLOKIA_OPTS>caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt</AB_JOLOKIA_OPTS>
-      </env>
-    </resources>
-  </configuration>
-</plugin>
+<properties>
+    <jolokia.protocol>https</jolokia.protocol>
+    <jolokia.host>*</jolokia.host>
+    <jolokia.port>8778</jolokia.port>
+    <jolokia.useSslClientAuthentication>true</jolokia.useSslClientAuthentication>
+    <jolokia.caCert>/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt</jolokia.caCert>
+    <jolokia.clientPrincipal.1>cn=hawtio-online.hawtio.svc</jolokia.clientPrincipal.1>
+    <jolokia.extendedClientCheck>true</jolokia.extendedClientCheck>
+    <jolokia.discoveryEnabled>false</jolokia.discoveryEnabled>
+</properties>
 ```
 
 ## How to run locally
@@ -48,7 +38,7 @@ This example is intended to be used by deploying to a Kubernetes/OpenShift clust
 To deploy it to a cluster, firstly change the container image name in [pom.xml](pom.xml) to fit your development environment. (The default image name is `quay.io/hawtio/hawtio-online-example-camel-springboot:latest`, which should be pushed to the `hawtio` organisation on [Quay.io](https://quay.io/).)
 
 ```xml
-    <jkube.generator.name>quay.io/hawtio/%a:latest</jkube.generator.name>
+    <jkube.container-image.name>quay.io/hawtio/%a:latest</jkube.container-image.name>
 ```
 
 Then build the project and container image:
@@ -73,9 +63,10 @@ After deployment is successful and the pod has started, the application log can 
 
 ```console
 $ hawtio-online-example-camel-springboot
-+ hawtio-online-example-camel-springboot-7f578548d6-s27j4 › spring-boot
++ hawtio-online-example-camel-springboot-7d456c879-pk945 › spring-boot
 Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
-INFO exec  java -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp ".:/deployments/*" org.springframework.boot.loader.JarLauncher  
+INFO exec -a "java" java -XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -javaagent:opt/jolokia-agent-jvm-2.1.1-javaagent.jar=protocol=https,host=*,port=8778,useSslClientAuthentication=true,caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,clientPrincipal.1=cn=hawtio-online.hawtio.svc,extendedClientCheck=true,discoveryEnabled=false -cp ".:/deployments/*" org.springframework.boot.loader.launch.JarLauncher
+INFO running in /deployments
  _________________________________________ 
 < Hawtio Online Camel Spring Boot Example >
  ----------------------------------------- 
@@ -85,22 +76,21 @@ INFO exec  java -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=con
                 ||----w |
                 ||     ||
 
+2024-10-24T19:03:59.663Z  INFO 1 --- [           main] i.h.o.e.s.SampleSpringBootService        : Starting SampleSpringBootService using Java 21.0.5 with PID 1 (/deployments/hawtio-online-example-camel-springboot-1.0.0.jar started by 1000710000 in /deployments)
+2024-10-24T19:03:59.673Z  INFO 1 --- [           main] i.h.o.e.s.SampleSpringBootService        : No active profile set, falling back to 1 default profile: "default"
 I> No access restrictor found, access to any MBean is allowed
-Jolokia: Agent started with URL https://172.17.11.234:8778/jolokia/
-2023-11-23T03:51:12.505Z  INFO 1 --- [           main] i.h.o.e.s.SampleSpringBootService        : Starting SampleSpringBootService using Java 17.0.9 with PID 1 (/deployments/BOOT-INF/classes started by jboss in /deployments)
-2023-11-23T03:51:12.512Z  INFO 1 --- [           main] i.h.o.e.s.SampleSpringBootService        : No active profile set, falling back to 1 default profile: "default"
-2023-11-23T03:51:15.938Z  INFO 1 --- [           main] o.a.c.i.e.DefaultCamelContextExtension   : Detected: camel-debug JAR (Enabling Camel Debugging)
-2023-11-23T03:51:17.021Z  INFO 1 --- [           main] org.xnio                                 : XNIO version 3.8.8.Final
-2023-11-23T03:51:17.037Z  INFO 1 --- [           main] org.xnio.nio                             : XNIO NIO Implementation Version 3.8.8.Final
-2023-11-23T03:51:17.077Z  INFO 1 --- [           main] org.jboss.threads                        : JBoss Threads version 3.5.0.Final
-2023-11-23T03:51:17.502Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Apache Camel 4.1.0 (SampleCamelSpringBoot) is starting
-2023-11-23T03:51:17.582Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzComponent   : Setting org.quartz.scheduler.jmx.export=true to ensure QuartzScheduler(s) will be enlisted in JMX
-2023-11-23T03:51:17.617Z  INFO 1 --- [           main] org.quartz.impl.StdSchedulerFactory      : Using default implementation for ThreadExecutor
-2023-11-23T03:51:17.621Z  INFO 1 --- [           main] org.quartz.simpl.SimpleThreadPool        : Job execution threads will use class loader of thread: main
-2023-11-23T03:51:17.632Z  INFO 1 --- [           main] org.quartz.core.SchedulerSignalerImpl    : Initialized Scheduler Signaller of type: class org.quartz.core.SchedulerSignalerImpl
-2023-11-23T03:51:17.633Z  INFO 1 --- [           main] org.quartz.core.QuartzScheduler          : Quartz Scheduler v.2.3.2 created.
-2023-11-23T03:51:17.633Z  INFO 1 --- [           main] org.quartz.simpl.RAMJobStore             : RAMJobStore initialized.
-2023-11-23T03:51:17.638Z  INFO 1 --- [           main] org.quartz.core.QuartzScheduler          : Scheduler meta-data: Quartz Scheduler (v2.3.2) 'DefaultQuartzScheduler-SampleCamelSpringBoot' with instanceId 'NON_CLUSTERED'
+Jolokia: Agent started with URL https://10.128.0.27:8778/jolokia/
+2024-10-24T19:04:02.027Z  INFO 1 --- [           main] org.xnio                                 : XNIO version 3.8.16.Final
+2024-10-24T19:04:02.037Z  INFO 1 --- [           main] org.xnio.nio                             : XNIO NIO Implementation Version 3.8.16.Final
+2024-10-24T19:04:02.063Z  INFO 1 --- [           main] org.jboss.threads                        : JBoss Threads version 3.5.0.Final
+2024-10-24T19:04:02.459Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Apache Camel 4.8.0 (SampleCamel) is starting
+2024-10-24T19:04:02.506Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzComponent   : Setting org.quartz.scheduler.jmx.export=true to ensure QuartzScheduler(s) will be enlisted in JMX
+2024-10-24T19:04:02.529Z  INFO 1 --- [           main] org.quartz.impl.StdSchedulerFactory      : Using default implementation for ThreadExecutor
+2024-10-24T19:04:02.531Z  INFO 1 --- [           main] org.quartz.simpl.SimpleThreadPool        : Job execution threads will use class loader of thread: main
+2024-10-24T19:04:02.538Z  INFO 1 --- [           main] org.quartz.core.SchedulerSignalerImpl    : Initialized Scheduler Signaller of type: class org.quartz.core.SchedulerSignalerImpl
+2024-10-24T19:04:02.538Z  INFO 1 --- [           main] org.quartz.core.QuartzScheduler          : Quartz Scheduler v.2.3.2 created.
+2024-10-24T19:04:02.539Z  INFO 1 --- [           main] org.quartz.simpl.RAMJobStore             : RAMJobStore initialized.
+2024-10-24T19:04:02.542Z  INFO 1 --- [           main] org.quartz.core.QuartzScheduler          : Scheduler meta-data: Quartz Scheduler (v2.3.2) 'DefaultQuartzScheduler-SampleCamel' with instanceId 'NON_CLUSTERED'
   Scheduler class: 'org.quartz.core.QuartzScheduler' - running locally.
   NOT STARTED.
   Currently in standby mode.
@@ -108,20 +98,20 @@ Jolokia: Agent started with URL https://172.17.11.234:8778/jolokia/
   Using thread pool 'org.quartz.simpl.SimpleThreadPool' - with 10 threads.
   Using job-store 'org.quartz.simpl.RAMJobStore' - which does not support persistence. and is not clustered.
 
-2023-11-23T03:51:17.638Z  INFO 1 --- [           main] org.quartz.impl.StdSchedulerFactory      : Quartz scheduler 'DefaultQuartzScheduler-SampleCamelSpringBoot' initialized from an externally provided properties instance.
-2023-11-23T03:51:17.638Z  INFO 1 --- [           main] org.quartz.impl.StdSchedulerFactory      : Quartz scheduler version: 2.3.2
-2023-11-23T03:51:17.651Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzEndpoint    : Job Camel_SampleCamelSpringBoot.cron (cron=0/10 * * * * ?, triggerType=CronTriggerImpl, jobClass=CamelJob) is scheduled. Next fire date is 2023-11-23T03:51:20.000+0000
-2023-11-23T03:51:17.688Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzEndpoint    : Job Camel_SampleCamelSpringBoot.simple (cron=null, triggerType=SimpleTriggerImpl, jobClass=CamelJob) is scheduled. Next fire date is 2023-11-23T03:51:17.685+0000
-2023-11-23T03:51:17.733Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Routes startup (started:2)
-2023-11-23T03:51:17.733Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started cron (quartz://cron)
-2023-11-23T03:51:17.733Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started simple (quartz://simple)
-2023-11-23T03:51:17.733Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Apache Camel 4.1.0 (SampleCamelSpringBoot) started in 230ms (build:0ms init:0ms start:230ms)
-2023-11-23T03:51:17.735Z  INFO 1 --- [           main] o.a.camel.impl.debugger.BacklogDebugger  : Enabling Camel debugger
-2023-11-23T03:51:17.735Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzComponent   : Starting Quartz scheduler: org.quartz.impl.StdScheduler@72b53f27
-2023-11-23T03:51:17.740Z  INFO 1 --- [           main] org.quartz.core.QuartzScheduler          : Scheduler DefaultQuartzScheduler-SampleCamelSpringBoot_$_NON_CLUSTERED started.
-2023-11-23T03:51:17.744Z  INFO 1 --- [           main] i.h.o.e.s.SampleSpringBootService        : Started SampleSpringBootService in 6.646 seconds (process running for 7.617)
+2024-10-24T19:04:02.542Z  INFO 1 --- [           main] org.quartz.impl.StdSchedulerFactory      : Quartz scheduler 'DefaultQuartzScheduler-SampleCamel' initialized from an externally provided properties instance.
+2024-10-24T19:04:02.542Z  INFO 1 --- [           main] org.quartz.impl.StdSchedulerFactory      : Quartz scheduler version: 2.3.2
+2024-10-24T19:04:02.557Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzEndpoint    : Job Camel_SampleCamel.cron (cron=0/10 * * * * ?, triggerType=CronTriggerImpl, jobClass=CamelJob) is scheduled. Next fire date is 2024-10-24T19:04:10.000+0000
+2024-10-24T19:04:02.579Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzEndpoint    : Job Camel_SampleCamel.simple (cron=null, triggerType=SimpleTriggerImpl, jobClass=CamelJob) is scheduled. Next fire date is 2024-10-24T19:04:02.577+0000
+2024-10-24T19:04:02.596Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Routes startup (total:2)
+2024-10-24T19:04:02.596Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started cron (quartz://cron)
+2024-10-24T19:04:02.596Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started simple (quartz://simple)
+2024-10-24T19:04:02.596Z  INFO 1 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Apache Camel 4.8.0 (SampleCamel) started in 136ms (build:0ms init:0ms start:136ms)
+2024-10-24T19:04:02.597Z  INFO 1 --- [           main] o.a.c.i.debugger.DefaultBacklogDebugger  : Enabling Camel debugger
+2024-10-24T19:04:02.598Z  INFO 1 --- [           main] o.a.c.component.quartz.QuartzComponent   : Starting Quartz scheduler: org.quartz.impl.StdScheduler@3fdede3a
+2024-10-24T19:04:02.598Z  INFO 1 --- [           main] org.quartz.core.QuartzScheduler          : Scheduler DefaultQuartzScheduler-SampleCamel_$_NON_CLUSTERED started.
+2024-10-24T19:04:02.599Z  INFO 1 --- [           main] i.h.o.e.s.SampleSpringBootService        : Started SampleSpringBootService in 3.266 seconds (process running for 3.738)
 Hello Camel! - simple
-2023-11-23T03:51:17.788Z  INFO 1 --- [melJMXConnector] o.a.c.c.debug.JmxConnectorService        : JMX Connector thread started and listening at: service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel
+2024-10-24T19:04:02.618Z  INFO 1 --- [gerJMXConnector] o.a.c.i.d.DebuggerJmxConnectorService    : Debugger JMXConnector listening at: service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel
 Hello Camel! - cron
 Hello Camel! - simple
 Hello Camel! - cron

--- a/camel-springboot/pom.xml
+++ b/camel-springboot/pom.xml
@@ -13,9 +13,18 @@
   <description>Hawtio Online :: Sample Camel Spring Boot 3.x application</description>
 
   <properties>
-    <jkube.generator.name>quay.io/hawtio/%a:latest</jkube.generator.name>
+    <jkube.container-image.name>quay.io/hawtio/%a:latest</jkube.container-image.name>
     <!-- Use Jib in order not to depend on docker nor podman -->
     <jkube.build.strategy>jib</jkube.build.strategy>
+
+    <jolokia.protocol>https</jolokia.protocol>
+    <jolokia.host>*</jolokia.host>
+    <jolokia.port>8778</jolokia.port>
+    <jolokia.useSslClientAuthentication>true</jolokia.useSslClientAuthentication>
+    <jolokia.caCert>/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt</jolokia.caCert>
+    <jolokia.clientPrincipal.1>cn=hawtio-online.hawtio.svc</jolokia.clientPrincipal.1>
+    <jolokia.extendedClientCheck>true</jolokia.extendedClientCheck>
+    <jolokia.discoveryEnabled>false</jolokia.discoveryEnabled>
   </properties>
 
   <dependencyManagement>
@@ -112,6 +121,31 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin-version}</version>
+        <executions>
+          <execution>
+            <id>copy-jolokia-agent</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.jolokia</groupId>
+                  <artifactId>jolokia-agent-jvm</artifactId>
+                  <version>${jolokia-version}</version>
+                  <classifier>javaagent</classifier>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.basedir}/target</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot-version}</version>
@@ -136,19 +170,39 @@
           </execution>
         </executions>
         <configuration>
-          <resources>
-            <env>
-              <!--
-                By default, JKube plugin sets up a Jolokia agent with HTTPS and
-                SSL client authentication enabled. The only necessary configurations
-                are the client principal that matches the Hawtio Online instance
-                (the default is `hawtio-online.hawtio.svc`) and the CA cert to
-                specify `service-ca.crt` instead of the default `ca.crt`.
-              -->
-              <AB_JOLOKIA_AUTH_OPENSHIFT>cn=hawtio-online.hawtio.svc</AB_JOLOKIA_AUTH_OPENSHIFT>
-              <AB_JOLOKIA_OPTS>caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt</AB_JOLOKIA_OPTS>
-            </env>
-          </resources>
+          <images>
+            <image>
+              <name>${jkube.container-image.name}</name>
+              <build>
+                <from>registry.access.redhat.com/ubi9/openjdk-21:latest</from>
+                <workdir>/deployments</workdir>
+                <assembly>
+                  <targetDir>/deployments</targetDir>
+                  <inline>
+                    <id>jolokia-agent</id>
+                    <files>
+                      <file>
+                        <source>
+                          ${project.basedir}/target/jolokia-agent-jvm-${jolokia-version}-javaagent.jar
+                        </source>
+                        <outputDirectory>opt</outputDirectory>
+                      </file>
+                    </files>
+                  </inline>
+                </assembly>
+                <env>
+                  <JAVA_APP_DIR>/deployments</JAVA_APP_DIR>
+                  <JAVA_MAIN_CLASS>org.springframework.boot.loader.launch.JarLauncher</JAVA_MAIN_CLASS>
+                  <JAVA_OPTS_APPEND>-javaagent:opt/jolokia-agent-jvm-${jolokia-version}-javaagent.jar=protocol=${jolokia.protocol},host=${jolokia.host},port=${jolokia.port},useSslClientAuthentication=${jolokia.useSslClientAuthentication},caCert=${jolokia.caCert},clientPrincipal.1=${jolokia.clientPrincipal.1},extendedClientCheck=${jolokia.extendedClientCheck},discoveryEnabled=${jolokia.discoveryEnabled}</JAVA_OPTS_APPEND>
+                </env>
+                <ports>
+                  <port>8080</port>
+                  <port>8778</port>
+                  <port>9779</port>
+                </ports>
+              </build>
+            </image>
+          </images>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <maven-antrun-plugin-version>3.1.0</maven-antrun-plugin-version>
     <maven-clean-plugin-version>3.4.0</maven-clean-plugin-version>
     <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
+    <maven-dependency-plugin-version>3.8.0</maven-dependency-plugin-version>
     <maven-failsafe-plugin-version>3.5.0</maven-failsafe-plugin-version>
     <maven-surefire-plugin-version>3.5.0</maven-surefire-plugin-version>
   </properties>


### PR DESCRIPTION
Adding multi-arch images for arm64, ppc64le and s390x. 
- Rebase to main
- Build multi-arch images for quarkus using quarkus-container-image-jib extension
- Build multi-arch images for springboot using kubernetes-maven-plugin (using ubi9/openjdk-xx images from RH)