### PR TITLE
fix(examples): Updated property for trace

### DIFF
--- a/camel-quarkus-kubernetes/src/main/resources/application.properties
+++ b/camel-quarkus-kubernetes/src/main/resources/application.properties
@@ -7,9 +7,7 @@ quarkus.log.category."org.apache.camel".level = INFO
 camel.context.name = SampleCamel
 
 # Enable the Camel plugin Trace tab
-#camel.main.tracing = true
-#camel.main.backlogTracing = true
-#camel.main.useBreadcrumb = true
+#camel.trace.enabled = true
 
 # Enable the Camel plugin Debug tab even in non-development environment
 quarkus.camel.debug.enabled = true

--- a/camel-quarkus-openshift/src/main/resources/application.properties
+++ b/camel-quarkus-openshift/src/main/resources/application.properties
@@ -17,9 +17,7 @@ quarkus.log.category."org.apache.camel".level = INFO
 camel.context.name = SampleCamel
 
 # Enable the Camel plugin Trace tab
-#camel.main.tracing = true
-#camel.main.backlogTracing = true
-#camel.main.useBreadcrumb = true
+#camel.trace.enabled = true
 
 # Enable the Camel plugin Debug tab even in non-development environment
 quarkus.camel.debug.enabled = true

--- a/camel-springboot/src/main/resources/application.properties
+++ b/camel-springboot/src/main/resources/application.properties
@@ -13,9 +13,7 @@ logging.level.io.undertow = WARN
 camel.springboot.name = SampleCamel
 
 # Enable the Camel plugin Trace tab
-#camel.springboot.tracing = true
-#camel.springboot.backlog-tracing = true
-#camel.springboot.use-breadcrumb = true
+#camel.trace.enabled = true
 
 quartz.cron = 0/10 * * * * ?
 quartz.repeatInterval = 10000


### PR DESCRIPTION
Related: https://github.com/hawtio/hawtio/pull/3917

Updates the trace properties in the examples to use current 4.5 property camel.trace.enabled

https://camel.apache.org/manual/camel-4x-upgrade-guide-4_5.html#_camel_spring_boot